### PR TITLE
Eliminar relacion proyecto ticket

### DIFF
--- a/app/controllers/tickets_controller.ts
+++ b/app/controllers/tickets_controller.ts
@@ -11,7 +11,7 @@ export default class TicketsController {
     const data = request.only([
       'titulo',
       'descripcion',
-      'estado_id',
+      'estadoid',
       'prioridad',
       'cliente',
       'usuarioasignado',

--- a/app/models/proyectos.ts
+++ b/app/models/proyectos.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo, hasMany } from '@adonisjs/lucid/orm'
+import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Cliente from '../models/clientes.js'
 

--- a/app/models/proyectos.ts
+++ b/app/models/proyectos.ts
@@ -1,9 +1,7 @@
 import { DateTime } from 'luxon'
 import { BaseModel, column, belongsTo, hasMany } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
-import Ticket from '../models/tickets.js'
 import Cliente from '../models/clientes.js'
-import type { HasMany } from '@adonisjs/lucid/types/relations'
 
 export default class Proyecto extends BaseModel {
   @column({ isPrimary: true })
@@ -17,9 +15,6 @@ export default class Proyecto extends BaseModel {
 
   @belongsTo(() => Cliente)
   declare cliente: BelongsTo<typeof Cliente>
-
-  @hasMany(() => Ticket)
-  declare tickets: HasMany<typeof Ticket>
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime

--- a/app/models/tickets.ts
+++ b/app/models/tickets.ts
@@ -5,7 +5,6 @@ import Cliente from '../models/clientes.js'
 import Usuario from '../models/usuarios.js'
 import Categoria from '../models/categorias.js'
 import Servicio from '../models/servicios.js'
-import Proyecto from '../models/proyectos.js'
 import EstadoTicket from '../models/estados_ticket.js'
 import Prioridad from '../models/prioridades.js'
 
@@ -37,9 +36,6 @@ export default class Ticket extends BaseModel {
   @column()
   declare servicioId: number
 
-  @column()
-  declare proyectoId: number
-
   @column.dateTime({ autoCreate: true })
   declare fechaAsignacion: DateTime
 
@@ -60,9 +56,6 @@ export default class Ticket extends BaseModel {
 
   @belongsTo(() => Servicio)
   declare servicio: BelongsTo<typeof Servicio>
-
-  @belongsTo(() => Proyecto)
-  declare proyecto: BelongsTo<typeof Proyecto>
 
   @belongsTo(() => EstadoTicket, { foreignKey: 'estadoId' })
   declare estado: BelongsTo<typeof EstadoTicket>

--- a/database/migrations/1746562085155_create_tickets_table.ts
+++ b/database/migrations/1746562085155_create_tickets_table.ts
@@ -48,12 +48,6 @@ export default class extends BaseSchema {
         .references('id')
         .inTable('servicios')
         .onDelete('CASCADE')
-      table
-        .integer('proyecto_id')
-        .unsigned()
-        .references('id')
-        .inTable('proyectos')
-        .onDelete('SET NULL')
       table.timestamp('fecha_asignacion', { useTz: true }).defaultTo(this.now())
       table.timestamp('created_at')
       table.timestamp('updated_at')


### PR DESCRIPTION
Se elimino la relación entre las tablas ticket y proyectos ya que no había una unión viable entre ella modificando migraciones y modelos para que no quedara ningún rastro